### PR TITLE
Remove redundant interfaces

### DIFF
--- a/bundles/org.palladiosimulator.retriever.extraction.rules/src/org/palladiosimulator/retriever/extraction/rules/EcmaScriptRules.xtend
+++ b/bundles/org.palladiosimulator.retriever.extraction.rules/src/org/palladiosimulator/retriever/extraction/rules/EcmaScriptRules.xtend
@@ -24,7 +24,7 @@ import org.palladiosimulator.retriever.extraction.commonalities.CompUnitOrName
 import org.palladiosimulator.retriever.extraction.engine.Rule
 import org.palladiosimulator.retriever.extraction.rules.data.GatewayRoute
 import org.palladiosimulator.retriever.extraction.blackboard.RetrieverBlackboard
-import org.palladiosimulator.retriever.extraction.commonalities.HTTPMethod
+import org.palladiosimulator.retriever.extraction.commonalities.RESTOperationName
 
 class EcmaScriptRules implements Rule {
 
@@ -86,7 +86,7 @@ class EcmaScriptRules implements Rule {
 					pcmDetector.detectRequiredInterface(GATEWAY_NAME, mappedURL)
 				}
 				pcmDetector.detectProvidedOperation(GATEWAY_NAME, null,
-					new RESTName(hostname, "/" + url, HTTPMethod.any))
+					new RESTOperationName(hostname, "/" + url))
 			}
 		}
 	}
@@ -279,7 +279,7 @@ class EcmaScriptRules implements Rule {
 				return route.applyTo(url)
 			}
 		}
-		return new RESTName(host, url, HTTPMethod.any)
+		return new RESTName(host, url)
 	}
 
 	override isBuildRule() {

--- a/bundles/org.palladiosimulator.retriever.extraction.rules/src/org/palladiosimulator/retriever/extraction/rules/JaxRSRules.xtend
+++ b/bundles/org.palladiosimulator.retriever.extraction.rules/src/org/palladiosimulator/retriever/extraction/rules/JaxRSRules.xtend
@@ -6,11 +6,11 @@ import static org.palladiosimulator.retriever.extraction.engine.RuleHelper.*
 import org.palladiosimulator.retriever.extraction.commonalities.CompUnitOrName
 import java.util.Set
 import org.palladiosimulator.retriever.extraction.engine.Rule
-import org.palladiosimulator.retriever.extraction.commonalities.RESTName
 import org.palladiosimulator.retriever.extraction.rules.util.RESTHelper
 import java.util.Map
 import org.palladiosimulator.retriever.extraction.commonalities.HTTPMethod
 import org.palladiosimulator.retriever.extraction.blackboard.RetrieverBlackboard
+import org.palladiosimulator.retriever.extraction.commonalities.RESTOperationName
 
 class JaxRSRules implements Rule {
 
@@ -67,7 +67,7 @@ class JaxRSRules implements Rule {
 					methodPath = RESTHelper.replaceArgumentsWithWildcards(methodPath)
 					// TODO: HTTP method switch-case
 					pcmDetector.detectCompositeProvidedOperation(identifier, m.resolveBinding,
-						new RESTName("SERVICE-HOST", methodPath, HTTPMethod.all))
+						new RESTOperationName("SERVICE-HOST", methodPath))
 				}
 			]
 			getFields(unit).forEach[f|pcmDetector.detectRequiredInterfaceWeakly(identifier, f)]
@@ -82,7 +82,7 @@ class JaxRSRules implements Rule {
 			getMethods(unit).forEach [ m |
 				if (SERVLET_METHODS.containsKey(m.name.identifier)) {
 					pcmDetector.detectProvidedOperation(identifier, m.resolveBinding,
-						new RESTName("SERVICE-HOST", path, Set.of(SERVLET_METHODS.get(m.name.identifier))))
+						new RESTOperationName("SERVICE-HOST", path, Set.of(SERVLET_METHODS.get(m.name.identifier))))
 				}
 			]
 			getFields(unit).forEach[f|pcmDetector.detectRequiredInterfaceWeakly(identifier, f)]

--- a/bundles/org.palladiosimulator.retriever.extraction.rules/src/org/palladiosimulator/retriever/extraction/rules/SpringRules.xtend
+++ b/bundles/org.palladiosimulator.retriever.extraction.rules/src/org/palladiosimulator/retriever/extraction/rules/SpringRules.xtend
@@ -21,6 +21,7 @@ import org.palladiosimulator.retriever.extraction.engine.Rule
 import org.palladiosimulator.retriever.extraction.rules.util.SpringHelper
 import org.palladiosimulator.retriever.extraction.rules.util.RESTHelper
 import org.palladiosimulator.retriever.extraction.blackboard.RetrieverBlackboard
+import org.palladiosimulator.retriever.extraction.commonalities.RESTOperationName
 
 class SpringRules implements Rule {
 	static final Logger LOG = Logger.getLogger(SpringRules)
@@ -188,7 +189,7 @@ class SpringRules implements Rule {
 						methodName = RESTHelper.replaceArgumentsWithWildcards(methodName);
 						val httpMethod = getHTTPMethod(m);
 						pcmDetector.detectCompositeProvidedOperation(identifier, m.resolveBinding,
-							new RESTName(applicationName, methodName, httpMethod));
+							new RESTOperationName(applicationName, methodName, httpMethod));
 					}
 				}
 			}
@@ -210,9 +211,10 @@ class SpringRules implements Rule {
 						requestedMapping = substituteVariables(requestedMapping, contextVariables);
 						var methodName = ifaceName + "/" + requestedMapping;
 						methodName = RESTHelper.replaceArgumentsWithWildcards(methodName);
-						val httpMethod = getHTTPMethod(m);
+						// Ignore HTTPMethod, only entire interfaces can be required right now.
+						// TODO: Find a way around this.
 						pcmDetector.detectCompositeRequiredInterface(identifier,
-							new RESTName(serviceIdentifier, methodName, httpMethod));
+							new RESTName(serviceIdentifier, methodName));
 					}
 				}
 			}
@@ -292,32 +294,32 @@ class SpringRules implements Rule {
 	def getHTTPMethod(MethodDeclaration m) {
 		val requestMapping = getMappingString(m, "RequestMapping");
 		if (requestMapping !== null) {
-			return HTTPMethod.any();
+			return HTTPMethod.WILDCARD;
 		}
 
 		val getMapping = getMappingString(m, "GetMapping");
 		if (getMapping !== null) {
-			return Set.of(HTTPMethod.GET);
+			return HTTPMethod.GET;
 		}
 
 		val postMapping = getMappingString(m, "PostMapping");
 		if (postMapping !== null) {
-			return Set.of(HTTPMethod.POST);
+			return HTTPMethod.POST;
 		}
 
 		val putMapping = getMappingString(m, "PutMapping");
 		if (putMapping !== null) {
-			return Set.of(HTTPMethod.PUT);
+			return HTTPMethod.PUT;
 		}
 
 		val deleteMapping = getMappingString(m, "DeleteMapping");
 		if (deleteMapping !== null) {
-			return Set.of(HTTPMethod.DELETE);
+			return HTTPMethod.DELETE;
 		}
 
 		val patchMapping = getMappingString(m, "PatchMapping");
 		if (patchMapping !== null) {
-			return Set.of(HTTPMethod.PATCH);
+			return HTTPMethod.PATCH;
 		}
 
 		return null;

--- a/bundles/org.palladiosimulator.retriever.extraction.rules/src/org/palladiosimulator/retriever/extraction/rules/data/GatewayRoute.xtend
+++ b/bundles/org.palladiosimulator.retriever.extraction.rules/src/org/palladiosimulator/retriever/extraction/rules/data/GatewayRoute.xtend
@@ -1,7 +1,6 @@
 package org.palladiosimulator.retriever.extraction.rules.data
 
 import org.palladiosimulator.retriever.extraction.commonalities.RESTName
-import org.palladiosimulator.retriever.extraction.commonalities.HTTPMethod
 
 class GatewayRoute {
 	static final String TRAILING_WILDCARD = "/**"
@@ -42,7 +41,7 @@ class GatewayRoute {
 			val newUrlSegments = urlSegments.subList(stripPrefixLength, urlSegments.length)
 			newUrl = toPath(newUrlSegments)
 		}
-		return new RESTName(targetHost, newUrl, HTTPMethod.any)
+		return new RESTName(targetHost, newUrl)
 	}
 
 	private static def calculateStripPrefixLength(String pathPattern) {

--- a/bundles/org.palladiosimulator.retriever.extraction/src/org/palladiosimulator/retriever/extraction/commonalities/DependencyUtils.java
+++ b/bundles/org.palladiosimulator.retriever.extraction/src/org/palladiosimulator/retriever/extraction/commonalities/DependencyUtils.java
@@ -67,7 +67,8 @@ public final class DependencyUtils {
                         if (!dependencies.contains(dependency)) {
                             // If a foreign dependency is part of the new common interface, it must
                             // not be created
-                            containsOtherDependency |= dependency.isPartOf(commonInterface);
+                            containsOtherDependency |= dependency.isPartOf(commonInterface)
+                                    && !commonInterface.isPartOf(dependency);
                         }
                     }
 

--- a/bundles/org.palladiosimulator.retriever.extraction/src/org/palladiosimulator/retriever/extraction/commonalities/EntireInterface.java
+++ b/bundles/org.palladiosimulator.retriever.extraction/src/org/palladiosimulator/retriever/extraction/commonalities/EntireInterface.java
@@ -10,14 +10,14 @@ import org.eclipse.jdt.core.dom.ITypeBinding;
 
 public class EntireInterface implements OperationInterface {
     private final Optional<ITypeBinding> binding;
-    private final InterfaceName name;
+    private final Name name;
 
-    public EntireInterface(final InterfaceName name) {
+    public EntireInterface(final Name name) {
         this.binding = Optional.empty();
         this.name = name;
     }
 
-    public EntireInterface(final ITypeBinding binding, final InterfaceName name) {
+    public EntireInterface(final ITypeBinding binding, final Name name) {
         this.binding = Optional.of(binding);
         this.name = name;
     }

--- a/bundles/org.palladiosimulator.retriever.extraction/src/org/palladiosimulator/retriever/extraction/commonalities/HTTPMethod.java
+++ b/bundles/org.palladiosimulator.retriever.extraction/src/org/palladiosimulator/retriever/extraction/commonalities/HTTPMethod.java
@@ -1,20 +1,23 @@
 package org.palladiosimulator.retriever.extraction.commonalities;
 
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.Set;
 
 public enum HTTPMethod {
-    GET, POST, PUT, DELETE, PATCH;
+    GET, POST, PUT, DELETE, PATCH,
+    /**
+     * Special value signaling all HTTPMethods are provided/required.
+     */
+    WILDCARD;
 
     public static boolean areAllPresent(Collection<HTTPMethod> httpMethods) {
-        return httpMethods.containsAll(all());
-    }
+        if (httpMethods.contains(HTTPMethod.WILDCARD)) {
+            return true;
+        }
 
-    public static Set<HTTPMethod> all() {
-        return Set.of(values());
-    }
-
-    public static Set<HTTPMethod> any() {
-        return Set.of();
+        Set<HTTPMethod> normalValues = new HashSet<>(Set.of(values()));
+        normalValues.remove(WILDCARD);
+        return httpMethods.containsAll(normalValues);
     }
 }

--- a/bundles/org.palladiosimulator.retriever.extraction/src/org/palladiosimulator/retriever/extraction/commonalities/JavaInterfaceName.java
+++ b/bundles/org.palladiosimulator.retriever.extraction/src/org/palladiosimulator/retriever/extraction/commonalities/JavaInterfaceName.java
@@ -21,7 +21,7 @@ public class JavaInterfaceName implements InterfaceName {
     }
 
     @Override
-    public InterfaceName createInterface(final String name) {
+    public InterfaceName createName(final String name) {
         return new JavaInterfaceName(name);
     }
 

--- a/bundles/org.palladiosimulator.retriever.extraction/src/org/palladiosimulator/retriever/extraction/commonalities/JavaOperationName.java
+++ b/bundles/org.palladiosimulator.retriever.extraction/src/org/palladiosimulator/retriever/extraction/commonalities/JavaOperationName.java
@@ -32,7 +32,7 @@ public class JavaOperationName implements OperationName {
     }
 
     @Override
-    public InterfaceName createInterface(final String name) {
+    public InterfaceName createName(final String name) {
         return new JavaInterfaceName(name);
     }
 

--- a/bundles/org.palladiosimulator.retriever.extraction/src/org/palladiosimulator/retriever/extraction/commonalities/Name.java
+++ b/bundles/org.palladiosimulator.retriever.extraction/src/org/palladiosimulator/retriever/extraction/commonalities/Name.java
@@ -6,7 +6,7 @@ import java.util.Optional;
 import java.util.Set;
 
 public interface Name {
-    InterfaceName createInterface(String name);
+    Name createName(String name);
 
     /**
      * @returns interfaces that this name is part of, sorted from specific to general.

--- a/bundles/org.palladiosimulator.retriever.extraction/src/org/palladiosimulator/retriever/extraction/commonalities/Operation.java
+++ b/bundles/org.palladiosimulator.retriever.extraction/src/org/palladiosimulator/retriever/extraction/commonalities/Operation.java
@@ -25,6 +25,15 @@ public class Operation implements OperationInterface {
     }
 
     @Override
+    public boolean isPartOf(final OperationInterface other) {
+        if (other instanceof Operation otherOperation) {
+            return Objects.equals(this.binding, otherOperation.binding);
+        } else {
+            return OperationInterface.super.isPartOf(other);
+        }
+    }
+
+    @Override
     public Map<OperationInterface, Set<Operation>> simplified() {
         return Map.of(this, Set.of(this));
     }

--- a/bundles/org.palladiosimulator.retriever.extraction/src/org/palladiosimulator/retriever/extraction/commonalities/Operation.java
+++ b/bundles/org.palladiosimulator.retriever.extraction/src/org/palladiosimulator/retriever/extraction/commonalities/Operation.java
@@ -27,7 +27,7 @@ public class Operation implements OperationInterface {
     @Override
     public boolean isPartOf(final OperationInterface other) {
         if (other instanceof Operation otherOperation) {
-            return Objects.equals(this.binding, otherOperation.binding);
+            return this.equals(other);
         } else {
             return OperationInterface.super.isPartOf(other);
         }

--- a/bundles/org.palladiosimulator.retriever.extraction/src/org/palladiosimulator/retriever/extraction/commonalities/RESTName.java
+++ b/bundles/org.palladiosimulator.retriever.extraction/src/org/palladiosimulator/retriever/extraction/commonalities/RESTName.java
@@ -141,7 +141,12 @@ public class RESTName implements InterfaceName {
 
     @Override
     public boolean isPartOf(final String iface) {
-        Optional<RESTName> parsedIface = parse(iface);
+        String pathCandidate = iface;
+        if (iface.contains("[")) {
+            int pathEnd = iface.indexOf('[');
+            pathCandidate = iface.substring(0, pathEnd);
+        }
+        Optional<RESTName> parsedIface = parse(pathCandidate);
         if (parsedIface.isEmpty()) {
             return false;
         }

--- a/bundles/org.palladiosimulator.retriever.extraction/src/org/palladiosimulator/retriever/extraction/commonalities/RESTName.java
+++ b/bundles/org.palladiosimulator.retriever.extraction/src/org/palladiosimulator/retriever/extraction/commonalities/RESTName.java
@@ -8,17 +8,13 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.Stack;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
-public class RESTName implements InterfaceName, OperationName {
+public class RESTName implements InterfaceName {
     private final String host;
     private final List<String> path;
-    private final Set<HTTPMethod> httpMethods;
 
-    public RESTName(final String host, final String path, final Set<HTTPMethod> httpMethods)
-            throws IllegalArgumentException {
+    public RESTName(final String host, final String path) throws IllegalArgumentException {
         this.host = host;
-        this.httpMethods = httpMethods;
         final Optional<List<String>> parsedPath = parsePath(host + path);
         if (parsedPath.isEmpty()) {
             throw new IllegalArgumentException("Could not parse path due to illegal format: \"" + path + "\"");
@@ -29,28 +25,9 @@ public class RESTName implements InterfaceName, OperationName {
         this.path.remove(0);
     }
 
-    public RESTName(final String host, final String path, final HTTPMethod... httpMethods)
-            throws IllegalArgumentException {
-        this(host, path, Set.of(httpMethods));
-    }
-
     @Override
     public String getName() {
-        return this.getInterface();
-    }
-
-    @Override
-    public String getInterface() {
         return this.toString();
-    }
-
-    @Override
-    public Optional<String> forInterface(final String baseInterface) {
-        if (!this.isPartOf(baseInterface)) {
-            return Optional.empty();
-        }
-
-        return Optional.of(this.getInterface());
     }
 
     @Override
@@ -68,10 +45,6 @@ public class RESTName implements InterfaceName, OperationName {
 
         final List<String> interfaces = new ArrayList<>(prefixes.size());
 
-        if (!this.httpMethods.isEmpty()) {
-            interfaces.add(this.getInterface());
-        }
-
         // Insert the prefixes in reverse since the most specific element is at index 0 there.
         while (!prefixes.empty()) {
             interfaces.add(this.toName(prefixes.pop()));
@@ -84,7 +57,7 @@ public class RESTName implements InterfaceName, OperationName {
     }
 
     @Override
-    public InterfaceName createInterface(final String name) {
+    public InterfaceName createName(final String name) {
         return parse(name).orElseThrow();
     }
 
@@ -102,23 +75,7 @@ public class RESTName implements InterfaceName, OperationName {
 
     @Override
     public String toString() {
-        final String pathString = this.toName(this.path);
-
-        String methodString = "";
-        if (!this.httpMethods.isEmpty()) {
-            methodString = "[";
-            if (HTTPMethod.areAllPresent(this.httpMethods)) {
-                methodString += "*";
-            } else {
-                List<String> httpMethodNames = this.httpMethods.stream()
-                    .map(HTTPMethod::toString)
-                    .collect(Collectors.toList());
-                methodString += String.join(",", httpMethodNames);
-            }
-            methodString += "]";
-        }
-
-        return pathString + methodString;
+        return this.toName(this.path);
     }
 
     private static Optional<List<String>> parsePath(final String string) {
@@ -138,7 +95,7 @@ public class RESTName implements InterfaceName, OperationName {
 
     @Override
     public int hashCode() {
-        return Objects.hash(this.host, this.path, this.httpMethods);
+        return Objects.hash(this.host, this.path);
     }
 
     @Override
@@ -150,8 +107,7 @@ public class RESTName implements InterfaceName, OperationName {
             return false;
         }
         final RESTName other = (RESTName) obj;
-        return Objects.equals(this.host, other.host) && Objects.equals(this.path, other.path)
-                && Objects.equals(this.httpMethods, other.httpMethods);
+        return Objects.equals(this.host, other.host) && Objects.equals(this.path, other.path);
     }
 
     @Override
@@ -170,10 +126,7 @@ public class RESTName implements InterfaceName, OperationName {
                 return Optional.empty();
             }
             String commonPath = toName(this.path.subList(0, commonSegments));
-            Set<HTTPMethod> httpMethodUnion = new HashSet<>();
-            httpMethodUnion.addAll(this.httpMethods);
-            httpMethodUnion.addAll(otherREST.httpMethods);
-            return Optional.of(new RESTName(this.host, commonPath, httpMethodUnion).toString());
+            return Optional.of(new RESTName(this.host, commonPath).toString());
         } else {
             // Implementation from Name
             final Set<String> interfaces = new HashSet<>(this.getInterfaces());
@@ -207,36 +160,21 @@ public class RESTName implements InterfaceName, OperationName {
                 return false;
             }
         }
-        if (restIface.path.size() == this.path.size() && !restIface.httpMethods.containsAll(this.httpMethods)) {
-            return false;
-        }
         return true;
     }
 
-    private static Optional<RESTName> parse(final String iface) {
-        final String[] parts = iface.split("\\[");
-        final Optional<List<String>> interfacePathOption = parsePath(parts[0]);
+    public static Optional<RESTName> parse(final String iface) {
+        if (iface.contains("[")) {
+            // If a HTTP method is present, iface is not a RESTName.
+            return Optional.empty();
+        }
+        final Optional<List<String>> interfacePathOption = parsePath(iface);
         if (interfacePathOption.isEmpty()) {
             return Optional.empty();
         }
         final List<String> path = interfacePathOption.get();
         final String host = path.remove(0);
 
-        // If no HTTP method is specified, handle it like a wildcard.
-        Set<HTTPMethod> httpMethods = HTTPMethod.all();
-        if (parts.length > 1) {
-            // Assume that a '[' implies a ']'.
-            final int end = parts[1].lastIndexOf(']');
-            final String httpMethodNames = parts[1].substring(0, end);
-
-            if (!httpMethodNames.equals("*")) {
-                // Narrow the scope.
-                httpMethods = Stream.of(httpMethodNames.split(","))
-                    .map(HTTPMethod::valueOf)
-                    .collect(Collectors.toSet());
-            }
-        }
-
-        return Optional.of(new RESTName(host, "/" + String.join("/", path), httpMethods));
+        return Optional.of(new RESTName(host, "/" + String.join("/", path)));
     }
 }

--- a/bundles/org.palladiosimulator.retriever.extraction/src/org/palladiosimulator/retriever/extraction/commonalities/RESTOperationName.java
+++ b/bundles/org.palladiosimulator.retriever.extraction/src/org/palladiosimulator/retriever/extraction/commonalities/RESTOperationName.java
@@ -1,0 +1,163 @@
+package org.palladiosimulator.retriever.extraction.commonalities;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class RESTOperationName implements OperationName {
+    private RESTName restName;
+    /**
+     * This set must never be empty.
+     */
+    private final Set<HTTPMethod> httpMethods;
+
+    public RESTOperationName(final String host, final String path, final Set<HTTPMethod> httpMethods)
+            throws IllegalArgumentException {
+        this(new RESTName(host, path), httpMethods);
+    }
+
+    public RESTOperationName(final String host, final String path, final HTTPMethod... httpMethods)
+            throws IllegalArgumentException {
+        this(host, path, Set.of(httpMethods));
+    }
+
+    private RESTOperationName(final RESTName restName, final Set<HTTPMethod> httpMethods) {
+        this.restName = restName;
+        if (httpMethods.isEmpty()) {
+            this.httpMethods = Set.of(HTTPMethod.WILDCARD);
+        } else {
+            this.httpMethods = Collections.unmodifiableSet(httpMethods);
+        }
+    }
+
+    @Override
+    public String getInterface() {
+        return this.toString();
+    }
+
+    @Override
+    public Optional<String> forInterface(final String baseInterface) {
+        if (!this.isPartOf(baseInterface)) {
+            return Optional.empty();
+        }
+
+        return Optional.of(this.getInterface());
+    }
+
+    @Override
+    public List<String> getInterfaces() {
+        return restName.getInterfaces();
+    }
+
+    @Override
+    public Name createName(final String name) {
+        return RESTOperationName.parse(name)
+            .orElseThrow();
+    }
+
+    @Override
+    public String toString() {
+        final String pathString = this.restName.toString();
+
+        if (this.httpMethods.isEmpty() || HTTPMethod.areAllPresent(this.httpMethods)) {
+            return pathString;
+        }
+
+        String httpMethodString = "";
+        List<String> httpMethodNames = this.httpMethods.stream()
+            .map(HTTPMethod::toString)
+            .collect(Collectors.toList());
+        httpMethodString = "[";
+        httpMethodString += String.join(",", httpMethodNames);
+        httpMethodString += "]";
+
+        return pathString + httpMethodString;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.restName, this.httpMethods);
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if ((obj == null) || (this.getClass() != obj.getClass())) {
+            return false;
+        }
+        final RESTOperationName other = (RESTOperationName) obj;
+        return Objects.equals(this.restName, other.restName) && Objects.equals(this.httpMethods, other.httpMethods);
+    }
+
+    @Override
+    public Optional<String> getCommonInterface(final Name other) {
+        if (other instanceof RESTOperationName otherREST) {
+            if (this.restName.equals(otherREST.restName)) {
+                Set<HTTPMethod> httpMethodUnion = new HashSet<>(this.httpMethods);
+                httpMethodUnion.addAll(otherREST.httpMethods);
+                return Optional.of(new RESTOperationName(this.restName, httpMethodUnion).toString());
+            } else {
+                return this.restName.getCommonInterface(otherREST.restName);
+            }
+        } else {
+            return OperationName.super.getCommonInterface(other);
+        }
+    }
+
+    @Override
+    public boolean isPartOf(final String iface) {
+        if (RESTName.parse(iface)
+            .isPresent()) {
+            return restName.isPartOf(iface);
+        }
+
+        Optional<RESTOperationName> parsedIface = parse(iface);
+        if (parsedIface.isEmpty()) {
+            return false;
+        }
+
+        RESTOperationName restIface = parsedIface.get();
+
+        if (!this.restName.equals(restIface.restName)) {
+            return false;
+        }
+
+        Set<HTTPMethod> normalHttpMethods = new HashSet<>(this.httpMethods);
+        normalHttpMethods.remove(HTTPMethod.WILDCARD);
+
+        if (!restIface.httpMethods.contains(HTTPMethod.WILDCARD)
+                && !restIface.httpMethods.containsAll(this.httpMethods)) {
+            return false;
+        }
+        return true;
+    }
+
+    public static Optional<RESTOperationName> parse(final String iface) {
+        final String[] parts = iface.split("\\[");
+        final Optional<RESTName> restNameOption = RESTName.parse(parts[0]);
+        if (restNameOption.isEmpty()) {
+            return Optional.empty();
+        }
+
+        Set<HTTPMethod> httpMethods = Set.of(HTTPMethod.WILDCARD);
+        if (parts.length > 1) {
+            // Assume that a '[' implies a ']'.
+            final int end = parts[1].lastIndexOf(']');
+            final String httpMethodNames = parts[1].substring(0, end);
+
+            // Narrow the scope.
+            httpMethods = Stream.of(httpMethodNames.split(","))
+                .map(HTTPMethod::valueOf)
+                .collect(Collectors.toSet());
+        }
+
+        return Optional.of(new RESTOperationName(restNameOption.get(), httpMethods));
+    }
+}

--- a/bundles/org.palladiosimulator.retriever.extraction/src/org/palladiosimulator/retriever/extraction/commonalities/RESTOperationUnion.java
+++ b/bundles/org.palladiosimulator.retriever.extraction/src/org/palladiosimulator/retriever/extraction/commonalities/RESTOperationUnion.java
@@ -1,0 +1,54 @@
+package org.palladiosimulator.retriever.extraction.commonalities;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+public class RESTOperationUnion implements OperationInterface {
+    private RESTOperationName name;
+
+    public RESTOperationUnion(RESTOperationName name) {
+        this.name = name;
+    }
+
+    @Override
+    public Name getName() {
+        return name;
+    }
+
+    @Override
+    public Map<OperationInterface, Set<Operation>> simplified() {
+        return Map.of(this, Set.of());
+    }
+
+    @Override
+    public String getInterface() {
+        return name.getInterface();
+    }
+
+    @Override
+    public String toString() {
+        return name.toString();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        RESTOperationUnion other = (RESTOperationUnion) obj;
+        return Objects.equals(name, other.name);
+    }
+
+}

--- a/bundles/org.palladiosimulator.retriever.extraction/src/org/palladiosimulator/retriever/extraction/engine/PCMDetector.java
+++ b/bundles/org.palladiosimulator.retriever.extraction/src/org/palladiosimulator/retriever/extraction/engine/PCMDetector.java
@@ -120,7 +120,7 @@ public class PCMDetector {
             .map(x -> x.getType())
             .map(x -> new EntireInterface(x, new JavaInterfaceName(NameConverter.toPCMIdentifier(x))))
             .collect(Collectors.toList());
-        this.detectRequiredInterface(unit, compositeRequired, detectWeakly, ifaces);
+        this.detectRequired(unit, compositeRequired, detectWeakly, ifaces);
     }
 
     public void detectRequiredInterface(final CompUnitOrName unit, final SingleVariableDeclaration parameter) {
@@ -141,11 +141,11 @@ public class PCMDetector {
 
     private void detectRequiredInterface(final CompUnitOrName unit, final boolean compositeRequired,
             final boolean detectWeakly, final OperationInterface iface) {
-        this.detectRequiredInterface(unit, compositeRequired, detectWeakly, List.of(iface));
+        this.detectRequired(unit, compositeRequired, detectWeakly, List.of(iface));
     }
 
-    private void detectRequiredInterface(final CompUnitOrName unit, final boolean compositeRequired,
-            final boolean detectWeakly, final Collection<OperationInterface> ifaces) {
+    private void detectRequired(final CompUnitOrName unit, final boolean compositeRequired, final boolean detectWeakly,
+            final Collection<OperationInterface> ifaces) {
         for (final OperationInterface iface : ifaces) {
             final boolean isProvided = this.compositeProvisions.containsRelated(iface) || this.components.values()
                 .stream()

--- a/tests/org.palladiosimulator.retriever.test/src/org/palladiosimulator/retriever/test/integration/ACMETest.java
+++ b/tests/org.palladiosimulator.retriever.test/src/org/palladiosimulator/retriever/test/integration/ACMETest.java
@@ -1,9 +1,7 @@
 package org.palladiosimulator.retriever.test.integration;
 
-import org.junit.jupiter.api.Disabled;
 import org.palladiosimulator.retriever.extraction.rules.JaxRSRules;
 
-@Disabled("Inconsistent repository, will be fixed")
 public class ACMETest extends CaseStudyTest {
 
     protected ACMETest() {

--- a/tests/org.palladiosimulator.retriever.test/src/org/palladiosimulator/retriever/test/integration/PetclinicTest.java
+++ b/tests/org.palladiosimulator.retriever.test/src/org/palladiosimulator/retriever/test/integration/PetclinicTest.java
@@ -19,7 +19,7 @@ public class PetclinicTest extends CaseStudyTest {
         this.assertComponentProvidesOperation("org_springframework_samples_petclinic_customers_web_PetResource",
                 "customers-service/petTypes[GET]", "customers-service/petTypes[GET]");
 
-        this.assertMaxParameterCount(2, "customers-service/owners[PUT]", "customers-service/owners[PUT]");
+        this.assertMaxParameterCount(2, "customers-service/owners[GET,POST,PUT]", "customers-service/owners[PUT]");
         this.assertMaxParameterCount(1, "api-gateway/api/gateway/owners[GET]", "api-gateway/api/gateway/owners[GET]");
 
         this.assertComponentRequiresComponent("org_springframework_samples_petclinic_customers_web_PetResource",

--- a/tests/org.palladiosimulator.retriever.test/src/org/palladiosimulator/retriever/test/model/InterfaceTest.java
+++ b/tests/org.palladiosimulator.retriever.test/src/org/palladiosimulator/retriever/test/model/InterfaceTest.java
@@ -19,8 +19,8 @@ import org.palladiosimulator.retriever.extraction.commonalities.JavaInterfaceNam
 import org.palladiosimulator.retriever.extraction.commonalities.JavaOperationName;
 import org.palladiosimulator.retriever.extraction.commonalities.Operation;
 import org.palladiosimulator.retriever.extraction.commonalities.OperationInterface;
-import org.palladiosimulator.retriever.extraction.commonalities.RESTName;
 import org.palladiosimulator.retriever.extraction.commonalities.RESTOperationName;
+import org.palladiosimulator.retriever.extraction.commonalities.RESTOperationUnion;
 
 public class InterfaceTest {
 
@@ -172,7 +172,8 @@ public class InterfaceTest {
         final List<OperationInterface> visibleProvisions = List.of(firstMethod, secondMethod);
 
         final Component builtComponent = builder.create(allDependencies, visibleProvisions);
-        final EntireInterface expectedInterface = new EntireInterface(new RESTName("test-host", "/common_interface"));
+        final OperationInterface expectedInterface = new RESTOperationUnion(
+                new RESTOperationName("test-host", "/common_interface"));
         assertTrue(builtComponent.provisions()
             .containsPartOf(expectedInterface));
 

--- a/tests/org.palladiosimulator.retriever.test/src/org/palladiosimulator/retriever/test/model/InterfaceTest.java
+++ b/tests/org.palladiosimulator.retriever.test/src/org/palladiosimulator/retriever/test/model/InterfaceTest.java
@@ -20,6 +20,7 @@ import org.palladiosimulator.retriever.extraction.commonalities.JavaOperationNam
 import org.palladiosimulator.retriever.extraction.commonalities.Operation;
 import org.palladiosimulator.retriever.extraction.commonalities.OperationInterface;
 import org.palladiosimulator.retriever.extraction.commonalities.RESTName;
+import org.palladiosimulator.retriever.extraction.commonalities.RESTOperationName;
 
 public class InterfaceTest {
 
@@ -65,7 +66,8 @@ public class InterfaceTest {
     @Test
     void singlePathOperation() {
         final ComponentBuilder builder = new ComponentBuilder(null);
-        final Operation expectedOperation = new Operation(null, new RESTName("test-host", "/method", HTTPMethod.GET));
+        final Operation expectedOperation = new Operation(null,
+                new RESTOperationName("test-host", "/method", HTTPMethod.GET));
         builder.provisions()
             .add(expectedOperation);
 
@@ -158,9 +160,9 @@ public class InterfaceTest {
     void entirePathInterface() {
         final ComponentBuilder builder = new ComponentBuilder(null);
         final Operation firstMethod = new Operation(null,
-                new RESTName("test-host", "/common_interface/first_method", HTTPMethod.GET));
+                new RESTOperationName("test-host", "/common_interface/first_method", HTTPMethod.GET));
         final Operation secondMethod = new Operation(null,
-                new RESTName("test-host", "/common_interface/second_method", HTTPMethod.GET));
+                new RESTOperationName("test-host", "/common_interface/second_method", HTTPMethod.GET));
         builder.provisions()
             .add(firstMethod);
         builder.provisions()
@@ -170,8 +172,7 @@ public class InterfaceTest {
         final List<OperationInterface> visibleProvisions = List.of(firstMethod, secondMethod);
 
         final Component builtComponent = builder.create(allDependencies, visibleProvisions);
-        final EntireInterface expectedInterface = new EntireInterface(
-                new RESTName("test-host", "/common_interface", HTTPMethod.GET));
+        final EntireInterface expectedInterface = new EntireInterface(new RESTName("test-host", "/common_interface"));
         assertTrue(builtComponent.provisions()
             .containsPartOf(expectedInterface));
 

--- a/tests/org.palladiosimulator.retriever.test/src/org/palladiosimulator/retriever/test/model/PathTest.java
+++ b/tests/org.palladiosimulator.retriever.test/src/org/palladiosimulator/retriever/test/model/PathTest.java
@@ -9,6 +9,7 @@ import org.palladiosimulator.retriever.extraction.commonalities.HTTPMethod;
 import org.palladiosimulator.retriever.extraction.commonalities.Operation;
 import org.palladiosimulator.retriever.extraction.commonalities.RESTName;
 import org.palladiosimulator.retriever.extraction.commonalities.RESTOperationName;
+import org.palladiosimulator.retriever.extraction.commonalities.RESTOperationUnion;
 
 public class PathTest {
 
@@ -43,13 +44,13 @@ public class PathTest {
     }
 
     @Test
-    void httpMethodsAreSpecializations() {
+    void httpMethodsMatchCorrectly() {
         final String path = "/some/path";
-        final RESTOperationName generalName = new RESTOperationName("test-host", path);
+        final RESTOperationName generalName = new RESTOperationName("test-host", path, HTTPMethod.WILDCARD);
         final RESTOperationName specificName = new RESTOperationName("test-host", path, HTTPMethod.GET);
 
-        final Operation generalOperation = new Operation(null, generalName);
-        final Operation specificOperation = new Operation(null, specificName);
+        final RESTOperationUnion generalOperation = new RESTOperationUnion(generalName);
+        final RESTOperationUnion specificOperation = new RESTOperationUnion(specificName);
 
         assertTrue(specificOperation.isPartOf(generalOperation));
         assertFalse(generalOperation.isPartOf(specificOperation));

--- a/tests/org.palladiosimulator.retriever.test/src/org/palladiosimulator/retriever/test/model/PathTest.java
+++ b/tests/org.palladiosimulator.retriever.test/src/org/palladiosimulator/retriever/test/model/PathTest.java
@@ -8,6 +8,7 @@ import org.palladiosimulator.retriever.extraction.commonalities.EntireInterface;
 import org.palladiosimulator.retriever.extraction.commonalities.HTTPMethod;
 import org.palladiosimulator.retriever.extraction.commonalities.Operation;
 import org.palladiosimulator.retriever.extraction.commonalities.RESTName;
+import org.palladiosimulator.retriever.extraction.commonalities.RESTOperationName;
 
 public class PathTest {
 
@@ -15,15 +16,15 @@ public class PathTest {
     void pathNamesAreReflective() {
         final String host = "test-host";
         final String path = "/some/path";
-        final RESTName pathName = new RESTName(host, path, HTTPMethod.any());
+        final RESTName pathName = new RESTName(host, path);
         assertTrue(pathName.isPartOf(host + path));
     }
 
     @Test
     void pathsArePartOfTheirPrefixes() {
         final String path = "/some/path";
-        final RESTName interfaceName = new RESTName("test-host", path, HTTPMethod.any());
-        final RESTName specificName = new RESTName("test-host", path + "/that/is/more/specific", HTTPMethod.GET);
+        final RESTName interfaceName = new RESTName("test-host", path);
+        final RESTName specificName = new RESTName("test-host", path + "/that/is/more/specific");
 
         assertTrue(specificName.isPartOf(interfaceName.getName()), "specific path is not part of its prefix");
         assertFalse(interfaceName.isPartOf(specificName.getName()), "prefix is part of a longer path");
@@ -33,10 +34,9 @@ public class PathTest {
     void prefixesAreSeparatorAware() {
         // This is NOT a legal prefix of "/some/path/..."
         final String somePath = "/some/pa";
-        final EntireInterface entireInterface = new EntireInterface(
-                new RESTName("test-host", somePath, HTTPMethod.any()));
-        final RESTName specificPathName = new RESTName("test-host", "/some/path/that/is/more/specific",
-                HTTPMethod.all());
+        final EntireInterface entireInterface = new EntireInterface(new RESTName("test-host", somePath));
+        final RESTOperationName specificPathName = new RESTOperationName("test-host",
+                "/some/path/that/is/more/specific");
         final Operation operation = new Operation(null, specificPathName);
 
         assertFalse(operation.isPartOf(entireInterface), "operation is part of illegal prefix");
@@ -45,15 +45,13 @@ public class PathTest {
     @Test
     void httpMethodsAreSpecializations() {
         final String path = "/some/path";
-        final RESTName generalRequirementName = new RESTName("test-host", path, HTTPMethod.any());
-        final RESTName specificName = new RESTName("test-host", path, HTTPMethod.GET);
-        final RESTName generalProvisionName = new RESTName("test-host", path, HTTPMethod.all());
+        final RESTOperationName generalName = new RESTOperationName("test-host", path);
+        final RESTOperationName specificName = new RESTOperationName("test-host", path, HTTPMethod.GET);
 
-        final Operation generalRequirementOperation = new Operation(null, generalRequirementName);
+        final Operation generalOperation = new Operation(null, generalName);
         final Operation specificOperation = new Operation(null, specificName);
-        final Operation generalProvisionOperation = new Operation(null, generalProvisionName);
 
-        assertTrue(specificOperation.isPartOf(generalRequirementOperation));
-        assertFalse(generalProvisionOperation.isPartOf(specificOperation));
+        assertTrue(specificOperation.isPartOf(generalOperation));
+        assertFalse(generalOperation.isPartOf(specificOperation));
     }
 }


### PR DESCRIPTION
Due to the structure of REST interfaces, they were sometimes present in multiple, redundant varieties. This lead to unexpected PlantUML visualizations.