### PR TITLE
Bugfix gitinfo

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -66,11 +66,12 @@ runs:
       shell: bash
       # Uses the latest Retriever or the Retriever with the same version that this action has
       run: |
-        if [[ "${{ env.action_version }}" == "main" ]]; then
-          echo "retriever=${{ github.api_url }}/repos/PalladioSimulator/Palladio-ReverseEngineering-Retriever/releases/latest" >> $GITHUB_ENV
-        else
-          echo "retriever=${{ github.api_url }}/repos/PalladioSimulator/Palladio-ReverseEngineering-Retriever/releases/tags/${{ env.action_version }}" >> $GITHUB_ENV
-        fi
+        echo "retriever=${{ github.api_url }}/repos/PalladioSimulator/Palladio-ReverseEngineering-Retriever/releases/latest" >> $GITHUB_ENV
+        #if [[ "${{ env.action_version }}" == "main" ]]; then
+        #  echo "retriever=${{ github.api_url }}/repos/PalladioSimulator/Palladio-ReverseEngineering-Retriever/releases/latest" >> $GITHUB_ENV
+        #else
+        #  echo "retriever=${{ github.api_url }}/repos/PalladioSimulator/Palladio-ReverseEngineering-Retriever/releases/tags/${{ env.action_version }}" >> $GITHUB_ENV
+        #fi
 
     - name: Gather Git Repository Info
       shell: bash
@@ -88,24 +89,35 @@ runs:
           OWNER=$(echo $REPO_PATH | cut -d'/' -f1)
           REPO_NAME=$(echo $REPO_PATH | cut -d'/' -f2 | sed 's/\.git$//')
           API_URL="https://api.github.com/repos/$OWNER/$REPO_NAME"
+
+          echo "variables worked"
           
           NUM_STARS=$(curl -s $API_URL | jq '.stargazers_count // 0')
           
+          echo "stars"
+          echo $NUM_STARS
+          
           # Get number of commits, handle the case where pagination info might not be present (less than 30 commits)
           COMMITS_LINK_HEADER=$(curl -s -I "${API_URL}/commits?per_page=1" | grep -i 'link:')
+          echo "commits link"
+          echo $COMMITS_LINK_HEADER
           if [ -z "$COMMITS_LINK_HEADER" ]; then
             NUM_COMMITS=$(curl -s "${API_URL}/commits" | jq 'length')
           else
             NUM_COMMITS=$(echo "$COMMITS_LINK_HEADER" | sed -E 's/.*page=([0-9]+)>; rel="last".*/\1/' || echo "1")
           fi
+          echo $NUM_COMMITS
           
           # Get number of contributors, handle the case where pagination info might not be present (less than 30 contributors)
           CONTRIBUTORS_LINK_HEADER=$(curl -s -I "${API_URL}/contributors?per_page=1" | grep -i 'link:')
+          echo "contributors link"
+          echo $CONTRIBUTORS_LINK_HEADER
           if [ -z "$CONTRIBUTORS_LINK_HEADER" ]; then
             NUM_CONTRIBUTORS=$(curl -s "${API_URL}/contributors" | jq 'length')
           else
             NUM_CONTRIBUTORS=$(echo "$CONTRIBUTORS_LINK_HEADER" | sed -E 's/.*page=([0-9]+)>; rel="last".*/\1/' || echo "1")
           fi
+          echo $CONTRIBUTORS_LINK_HEADER
 
           echo "|      Attribute    | Value |"
           echo "| ----------------- | ----- |"
@@ -126,7 +138,8 @@ runs:
         if [ -d "$SOURCE_PATH/.git" ]; then
           cd "$SOURCE_PATH"
           print_header >> "$GIT_INFO_FILE"
-          gather_git_info >> "$GIT_INFO_FILE"
+          # gather_git_info >> "$GIT_INFO_FILE"
+          gather_git_info
         else
           FOUND_REPO=false
           for d in "$SOURCE_PATH"/*; do
@@ -135,7 +148,8 @@ runs:
               if [ "$FOUND_REPO" = false ]; then
                 print_header >> "$GIT_INFO_FILE"
               fi
-              gather_git_info >> "$GIT_INFO_FILE"
+              # gather_git_info >> "$GIT_INFO_FILE"
+              gather_git_info
               FOUND_REPO=true
             fi
           done

--- a/action.yml
+++ b/action.yml
@@ -405,7 +405,7 @@ runs:
           } > "${TIMING_INFO_FILE}.tmp" && mv "${TIMING_INFO_FILE}.tmp" "$TIMING_INFO_FILE"
 
           # Extract the mean time without deviation
-          MEAN_TIME=$(awk -F'|' '/^[ ]*\|/{gsub(/[ ]/,""); print $2}' $TIMING_INFO_FILE | sed -n '3p' | awk '{print $1}' | sed 's/±.*//')
+          MEAN_TIME=$(awk -F'|' '/^[ ]*\|/{gsub(/[ ]/,""); print $2}' $TIMING_INFO_FILE | sed -n '3p')
           echo "execution_time=$MEAN_TIME" >> $GITHUB_ENV
                     
         else

--- a/action.yml
+++ b/action.yml
@@ -89,43 +89,24 @@ runs:
           OWNER=$(echo $REPO_PATH | cut -d'/' -f1)
           REPO_NAME=$(echo $REPO_PATH | cut -d'/' -f2 | sed 's/\.git$//')
           API_URL="https://api.github.com/repos/$OWNER/$REPO_NAME"
-
-          echo "variables worked"
           
           NUM_STARS=$(curl -s $API_URL | jq '.stargazers_count // 0')
           
-          echo "stars"
-          echo $NUM_STARS
-
-          echo $API_URL
-
-          RATE_LIMIT=$(curl -s https://api.github.com/rate_limit | jq '.rate.remaining')
-          echo "GitHub API rate limit remaining: $RATE_LIMIT"
-          
           # Get number of commits, handle the case where pagination info might not be present (less than 30 commits)
           COMMITS_LINK_HEADER=$(curl -I "${API_URL}/commits?per_page=1" | grep -i 'link:' || true)
-          echo "commits link"
-          echo $COMMITS_LINK_HEADER
           if [ -z "$COMMITS_LINK_HEADER" ]; then
             NUM_COMMITS=$(curl -s "${API_URL}/commits" | jq 'length')
           else
             NUM_COMMITS=$(echo "$COMMITS_LINK_HEADER" | sed -E 's/.*page=([0-9]+)>; rel="last".*/\1/' || echo "1")
           fi
-          echo $NUM_COMMITS
           
-          # Get number of contributors, handle the case where pagination info might not be present (less than 30 contributors)
-
-          curl -I "${API_URL}/contributors?per_page=1"
-          
+          # Get number of contributors, handle the case where pagination info might not be present (less than 30 contributors)          
           CONTRIBUTORS_LINK_HEADER=$(curl -s -I "${API_URL}/contributors?per_page=1" | grep -i 'link:' || true)
-          echo "contributors link"
-          echo $CONTRIBUTORS_LINK_HEADER
           if [ -z "$CONTRIBUTORS_LINK_HEADER" ]; then
             NUM_CONTRIBUTORS=$(curl -s "${API_URL}/contributors" | jq 'length')
           else
             NUM_CONTRIBUTORS=$(echo "$CONTRIBUTORS_LINK_HEADER" | sed -E 's/.*page=([0-9]+)>; rel="last".*/\1/' || echo "1")
           fi
-          echo $CONTRIBUTORS_LINK_HEADER
 
           echo "|      Attribute    | Value |"
           echo "| ----------------- | ----- |"
@@ -146,8 +127,7 @@ runs:
         if [ -d "$SOURCE_PATH/.git" ]; then
           cd "$SOURCE_PATH"
           print_header >> "$GIT_INFO_FILE"
-          # gather_git_info >> "$GIT_INFO_FILE"
-          gather_git_info
+          gather_git_info >> "$GIT_INFO_FILE"
         else
           FOUND_REPO=false
           for d in "$SOURCE_PATH"/*; do
@@ -156,7 +136,7 @@ runs:
               if [ "$FOUND_REPO" = false ]; then
                 print_header >> "$GIT_INFO_FILE"
               fi
-              # gather_git_info >> "$GIT_INFO_FILE"
+              gather_git_info >> "$GIT_INFO_FILE"
               gather_git_info
               FOUND_REPO=true
             fi

--- a/action.yml
+++ b/action.yml
@@ -66,11 +66,12 @@ runs:
       shell: bash
       # Uses the latest Retriever or the Retriever with the same version that this action has
       run: |
-        if [[ "${{ env.action_version }}" == "main" ]]; then
-          echo "retriever=${{ github.api_url }}/repos/PalladioSimulator/Palladio-ReverseEngineering-Retriever/releases/latest" >> $GITHUB_ENV
-        else
-          echo "retriever=${{ github.api_url }}/repos/PalladioSimulator/Palladio-ReverseEngineering-Retriever/releases/tags/${{ env.action_version }}" >> $GITHUB_ENV
-        fi
+        echo "retriever=${{ github.api_url }}/repos/PalladioSimulator/Palladio-ReverseEngineering-Retriever/releases/latest" >> $GITHUB_ENV
+        #if [[ "${{ env.action_version }}" == "main" ]]; then
+        #  echo "retriever=${{ github.api_url }}/repos/PalladioSimulator/Palladio-ReverseEngineering-Retriever/releases/latest" >> $GITHUB_ENV
+        #else
+        #  echo "retriever=${{ github.api_url }}/repos/PalladioSimulator/Palladio-ReverseEngineering-Retriever/releases/tags/${{ env.action_version }}" >> $GITHUB_ENV
+        #fi
 
     - name: Gather Git Repository Info
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -66,12 +66,11 @@ runs:
       shell: bash
       # Uses the latest Retriever or the Retriever with the same version that this action has
       run: |
-        echo "retriever=${{ github.api_url }}/repos/PalladioSimulator/Palladio-ReverseEngineering-Retriever/releases/latest" >> $GITHUB_ENV
-        #if [[ "${{ env.action_version }}" == "main" ]]; then
-        #  echo "retriever=${{ github.api_url }}/repos/PalladioSimulator/Palladio-ReverseEngineering-Retriever/releases/latest" >> $GITHUB_ENV
-        #else
-        #  echo "retriever=${{ github.api_url }}/repos/PalladioSimulator/Palladio-ReverseEngineering-Retriever/releases/tags/${{ env.action_version }}" >> $GITHUB_ENV
-        #fi
+        if [[ "${{ env.action_version }}" == "main" ]]; then
+          echo "retriever=${{ github.api_url }}/repos/PalladioSimulator/Palladio-ReverseEngineering-Retriever/releases/latest" >> $GITHUB_ENV
+        else
+          echo "retriever=${{ github.api_url }}/repos/PalladioSimulator/Palladio-ReverseEngineering-Retriever/releases/tags/${{ env.action_version }}" >> $GITHUB_ENV
+        fi
 
     - name: Gather Git Repository Info
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -101,11 +101,9 @@ runs:
 
           RATE_LIMIT=$(curl -s https://api.github.com/rate_limit | jq '.rate.remaining')
           echo "GitHub API rate limit remaining: $RATE_LIMIT"
-
-          curl -I "${API_URL}/commits?per_page=1"
           
           # Get number of commits, handle the case where pagination info might not be present (less than 30 commits)
-          COMMITS_LINK_HEADER=$(curl -I "${API_URL}/commits?per_page=1" | grep -i 'link:')
+          COMMITS_LINK_HEADER=$(curl -I "${API_URL}/commits?per_page=1" | grep -i 'link:' || true)
           echo "commits link"
           echo $COMMITS_LINK_HEADER
           if [ -z "$COMMITS_LINK_HEADER" ]; then
@@ -116,7 +114,10 @@ runs:
           echo $NUM_COMMITS
           
           # Get number of contributors, handle the case where pagination info might not be present (less than 30 contributors)
-          CONTRIBUTORS_LINK_HEADER=$(curl -s -I "${API_URL}/contributors?per_page=1" | grep -i 'link:')
+
+          curl -I "${API_URL}/contributors?per_page=1
+          
+          CONTRIBUTORS_LINK_HEADER=$(curl -s -I "${API_URL}/contributors?per_page=1" | grep -i 'link:' || true)
           echo "contributors link"
           echo $CONTRIBUTORS_LINK_HEADER
           if [ -z "$CONTRIBUTORS_LINK_HEADER" ]; then

--- a/action.yml
+++ b/action.yml
@@ -115,7 +115,7 @@ runs:
           
           # Get number of contributors, handle the case where pagination info might not be present (less than 30 contributors)
 
-          curl -I "${API_URL}/contributors?per_page=1
+          curl -I "${API_URL}/contributors?per_page=1"
           
           CONTRIBUTORS_LINK_HEADER=$(curl -s -I "${API_URL}/contributors?per_page=1" | grep -i 'link:' || true)
           echo "contributors link"

--- a/action.yml
+++ b/action.yml
@@ -92,14 +92,14 @@ runs:
           NUM_STARS=$(curl -s $API_URL | jq '.stargazers_count // 0')
           
           # Get number of commits, handle the case where pagination info might not be present (less than 30 commits)
-          COMMITS_LINK_HEADER=$(curl -I "${API_URL}/commits?per_page=1" | grep -i 'link:' || true)
+          COMMITS_LINK_HEADER=$(curl -s -I "${API_URL}/commits?per_page=1" | grep -i 'link:' || true)
           if [ -z "$COMMITS_LINK_HEADER" ]; then
             NUM_COMMITS=$(curl -s "${API_URL}/commits" | jq 'length')
           else
             NUM_COMMITS=$(echo "$COMMITS_LINK_HEADER" | sed -E 's/.*page=([0-9]+)>; rel="last".*/\1/' || echo "1")
           fi
           
-          # Get number of contributors, handle the case where pagination info might not be present (less than 30 contributors)          
+          # Get number of contributors, handle the case where pagination info might not be present (less than 30 contributors)
           CONTRIBUTORS_LINK_HEADER=$(curl -s -I "${API_URL}/contributors?per_page=1" | grep -i 'link:' || true)
           if [ -z "$CONTRIBUTORS_LINK_HEADER" ]; then
             NUM_CONTRIBUTORS=$(curl -s "${API_URL}/contributors" | jq 'length')
@@ -136,7 +136,6 @@ runs:
                 print_header >> "$GIT_INFO_FILE"
               fi
               gather_git_info >> "$GIT_INFO_FILE"
-              gather_git_info
               FOUND_REPO=true
             fi
           done

--- a/action.yml
+++ b/action.yml
@@ -96,9 +96,16 @@ runs:
           
           echo "stars"
           echo $NUM_STARS
+
+          echo $API_URL
+
+          RATE_LIMIT=$(curl -s https://api.github.com/rate_limit | jq '.rate.remaining')
+          echo "GitHub API rate limit remaining: $RATE_LIMIT"
+
+          curl -I "${API_URL}/commits?per_page=1"
           
           # Get number of commits, handle the case where pagination info might not be present (less than 30 commits)
-          COMMITS_LINK_HEADER=$(curl -s -I "${API_URL}/commits?per_page=1" | grep -i 'link:')
+          COMMITS_LINK_HEADER=$(curl -I "${API_URL}/commits?per_page=1" | grep -i 'link:')
           echo "commits link"
           echo $COMMITS_LINK_HEADER
           if [ -z "$COMMITS_LINK_HEADER" ]; then

--- a/action.yml
+++ b/action.yml
@@ -406,7 +406,7 @@ runs:
           } > "${TIMING_INFO_FILE}.tmp" && mv "${TIMING_INFO_FILE}.tmp" "$TIMING_INFO_FILE"
 
           # Extract the mean time without deviation
-          MEAN_TIME=$(awk -F'|' '/^[ ]*\|/{gsub(/[ ]/,""); print $2}' $TIMING_INFO_FILE | sed -n '3p')
+          MEAN_TIME=$(awk -F'|' '/^[ ]*\|/{print $2}' $TIMING_INFO_FILE | sed -n '3p' | sed 's/^[ ]*//')
           echo "execution_time=$MEAN_TIME" >> $GITHUB_ENV
                     
         else


### PR DESCRIPTION
grep command fails if the link header isn't present. Now the commands also work if there is only one contributor/commit (then the link header doesn't exist)