### PR TITLE
Complete migration to parent POM version 0.9.0

### DIFF
--- a/products/org.palladiosimulator.retriever.product/pom.xml
+++ b/products/org.palladiosimulator.retriever.product/pom.xml
@@ -4,16 +4,15 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
-		<groupId>org.palladiosimulator</groupId>
-		<artifactId>eclipse-parent-updatesite</artifactId>
-		<version>0.8.9</version>
+		<groupId>org.palladiosimulator.retriever</groupId>
+		<artifactId>parent</artifactId>
+		<version>5.2.1-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 
 	<groupId>org.palladiosimulator.retriever</groupId>
 	<artifactId>org.palladiosimulator.retriever.product</artifactId>
 	<name>[product] Retriever CLI</name>
-	<version>5.2.1-SNAPSHOT</version>
 	<packaging>eclipse-repository</packaging>
 
 	<!-- Without this, the native launcher artifacts can not be found -->

--- a/tests/org.palladiosimulator.retriever.test/pom.xml
+++ b/tests/org.palladiosimulator.retriever.test/pom.xml
@@ -4,16 +4,15 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
-		<groupId>org.palladiosimulator</groupId>
-		<artifactId>eclipse-parent-updatesite</artifactId>
-		<version>0.8.9</version>
+		<groupId>org.palladiosimulator.retriever</groupId>
+		<artifactId>parent</artifactId>
+		<version>5.2.1-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 
 	<groupId>org.palladiosimulator.retriever</groupId>
 	<artifactId>org.palladiosimulator.retriever.test</artifactId>
 	<name>[test-bundle] Retriever</name>
-	<version>5.2.1-SNAPSHOT</version>
 	<packaging>eclipse-test-plugin</packaging>
 
 	<build>


### PR DESCRIPTION
@Nicolas-Boltz @rsfzi I'm not sure why the `<relativePath>` was pointing to the aggregator POM in the root directory (which itself uses `eclipse-parent-updatesite` as its parent), while the Maven coordinates were referencing `eclipse-parent-updatesite` directly instead of the aggregator POM.